### PR TITLE
update pritter and delete eslint-config-prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ module.exports = {
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:prettier/recommended",
     "prettier",
-    "prettier/@typescript-eslint",
     "plugin:import/recommended",
     "plugin:import/typescript",
   ]

--- a/package.json
+++ b/package.json
@@ -1,16 +1,15 @@
 {
   "name": "eslint-config-tara",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "index.js",
   "license": "MIT",
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.24.0",
     "@typescript-eslint/parser": "^4.24.0",
-    "eslint": "^7.1.0",
-    "eslint-config-prettier": "^6.11.0",
-    "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-prettier": "^3.1.3",
-    "prettier": "^2.0.5",
-    "typescript": "^4.0.3"
+    "eslint": "^7.27.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-prettier": "^3.4.0",
+    "prettier": "^2.2.1",
+    "typescript": "^4.2.3"
   }
 }


### PR DESCRIPTION
## 概要
eslintを7.27.0にあげるにあたって、eslint-config-prettierががprettierに統合されたので削除しました。
諸々ライブラリをアップデートしました。

```
"eslint": "^7.1.0",    
"eslint-config-prettier": "^6.11.0",    
"eslint-plugin-import": "^2.20.2",    
"eslint-plugin-prettier": "^3.1.3",    
"prettier": "^2.0.5",    
"typescript": "^4.0.3"    
```

↓

```
"eslint": "^7.27.0",    
"eslint-plugin-import": "^2.22.1",    
"eslint-plugin-prettier": "^3.4.0",   
 "prettier": "^2.2.1",    
"typescript": "^4.2.3"
```