### PR TITLE
Use eslint-config-prettier instead eslint-plugin-prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,12 +16,6 @@ module.exports = {
     "import/extensions": "off",
     "import/no-unresolved": "off",
     'import/prefer-default-export': 'off',
-    "prettier/prettier": [
-      "error",
-      {
-        "printWidth": 120,
-      }
-    ]
   },
   "overrides": [
     {
@@ -36,7 +30,6 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:prettier/recommended",
     "prettier",
     "plugin:import/recommended",
     "plugin:import/typescript",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,8 @@
     "@typescript-eslint/eslint-plugin": "^4.24.0",
     "@typescript-eslint/parser": "^4.24.0",
     "eslint": "^7.27.0",
+    "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-prettier": "^3.4.0",
-    "prettier": "^2.2.1",
     "typescript": "^4.2.3"
   }
 }


### PR DESCRIPTION
## Description

Use `eslint-config-prettier` for disable Prettier rules on ESLint.

Ref. https://github.com/prettier/eslint-plugin-prettier#recommended-configuration